### PR TITLE
fix: 인증라우트 체크시 /user/nickname 라우트 제외하도록 정규표현식 수정

### DIFF
--- a/src/utils/isAuthorizedRequest.ts
+++ b/src/utils/isAuthorizedRequest.ts
@@ -4,7 +4,7 @@ import { COOKIE } from '@/app/api/_interceptor/utils/cookieUtils';
 
 export const isAuthorizedRequest = (request: NextRequest) => {
   const authRouteMatcher = new RegExp(
-    /(\/api)*\/(((project|user)(\/(?!(login|signup))).*)|((project|user)\s))/,
+    /(\/api)*\/(((project|user)(\/(?!(login|signup|nickname))).*)|((project|user)\s))/,
     'i',
   );
   if (!authRouteMatcher.test(request.nextUrl.pathname)) return true;


### PR DESCRIPTION
# 🎋 작업중인 브랜치 

fix/#12/fix-authroute-regex

<br/>

# 🔑  변경된 사항 

## 1. 인증라우트 체크시 /user/nickname 라우트 제외하도록 정규표현식 수정

<br/>

434e288b9f9067facc40b1d370de76d088e82c69

-  'api/user/nickname' 라우트는 아이디 중복체크를 위한 라우트 핸들러로, 인증이 필요하지 않기때문에, 정규표현식상으로 매칭되지 않게끔 수정했습니다. 

<br/>

# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.


<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
