### PR TITLE
Refactor/#17/refactor query options

### DIFF
--- a/src/app/StaticDataProvider.tsx
+++ b/src/app/StaticDataProvider.tsx
@@ -3,36 +3,24 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
-import {
-  getPositionList as getPositionListAPI,
-  getTechStackCategoryList,
-  getTechStackList as getTechStackListAPI,
-  getTechStackListWithCategory,
-} from '@/service/setting/setting';
 import { ReactNode } from 'react';
+import {
+  positionQueryOptions,
+  techCategoryQueryOptions,
+  techListQueryOptions,
+  techMapQueryOptions,
+} from '@/utils/tanstackQueryOptions/settingsQuery';
 
 async function StaticDataProvider({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();
 
-  const positions = queryClient.prefetchQuery({
-    queryKey: ['positions'],
-    queryFn: getPositionListAPI,
-  });
+  const positions = queryClient.prefetchQuery(positionQueryOptions());
 
-  const techs = queryClient.prefetchQuery({
-    queryKey: ['techStackCategoryList'],
-    queryFn: getTechStackCategoryList,
-  });
+  const techs = queryClient.prefetchQuery(techCategoryQueryOptions());
 
-  const techResponse = queryClient.prefetchQuery({
-    queryKey: ['techStackListWithCategory'],
-    queryFn: getTechStackListWithCategory,
-  });
+  const techResponse = queryClient.prefetchQuery(techMapQueryOptions());
 
-  const techStacks = queryClient.prefetchQuery({
-    queryKey: ['techStacks'],
-    queryFn: getTechStackListAPI,
-  });
+  const techStacks = queryClient.prefetchQuery(techListQueryOptions());
 
   await Promise.all([positions, techs, techResponse, techStacks]);
 

--- a/src/components/main/posts/TechStackDropdown.tsx
+++ b/src/components/main/posts/TechStackDropdown.tsx
@@ -5,16 +5,12 @@ import { useRecoilValue } from 'recoil';
 import { BsChevronDown } from '@react-icons/all-files/bs/BsChevronDown';
 import TechStackDropdownList from '../../ui/dropdown/TechStackDropdownList';
 import { useQuery } from '@tanstack/react-query';
-import {
-  ResponseBody,
-  TechStackCategory,
-  TechStackWithCategory,
-} from '@/utils/type';
-import {
-  getTechStackCategoryList,
-  getTechStackListWithCategory,
-} from '@/service/setting/setting';
+import { TechStackWithCategory } from '@/utils/type';
 import { selectedTechStackState } from '@/store/post/PostStateStore';
+import {
+  techCategoryQueryOptions,
+  techMapQueryOptions,
+} from '@/utils/tanstackQueryOptions/settingsQuery';
 
 const getSelectedTechStackText = (
   selectedTechStacks: TechStackWithCategory[],
@@ -49,23 +45,13 @@ const TechStackDropdown = () => {
     return () => document.removeEventListener('click', handleDocumentClick);
   }, []);
 
-  const { data: categoryResponse, isFetching: isFetchingCategory } = useQuery<
-    ResponseBody<TechStackCategory[]>,
-    Error
-  >({
-    queryKey: ['techStackCategoryList'],
-    queryFn: () => getTechStackCategoryList(),
-    staleTime: Infinity,
-  });
+  const { data: categoryResponse, isFetching: isFetchingCategory } = useQuery(
+    techCategoryQueryOptions(),
+  );
 
-  const { data: techStackResponse, isFetching: isFetchingTechStack } = useQuery<
-    ResponseBody<TechStackWithCategory[]>,
-    Error
-  >({
-    queryKey: ['techStackListWithCategory'],
-    queryFn: () => getTechStackListWithCategory(),
-    staleTime: Infinity,
-  });
+  const { data: techStackResponse, isFetching: isFetchingTechStack } = useQuery(
+    techMapQueryOptions(),
+  );
 
   if (isFetchingTechStack || isFetchingCategory)
     return (

--- a/src/hooks/common/usePositionList.tsx
+++ b/src/hooks/common/usePositionList.tsx
@@ -1,22 +1,14 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getPositionList as getPositionListAPI } from '@/service/setting/setting';
-import { PositionItem, ResponseBody } from '@/utils/type';
 import { useSetRecoilState } from 'recoil';
 import { snackbarState } from '@/store/CommonStateStore';
+import { positionQueryOptions } from '@/utils/tanstackQueryOptions/settingsQuery';
 
 export function usePositionList() {
   const setSnackBar = useSetRecoilState(snackbarState);
 
-  const { data, isFetching, isError } = useQuery<
-    ResponseBody<PositionItem[]>,
-    Error
-  >({
-    queryKey: ['positions'],
-    queryFn: () => getPositionListAPI(),
-    staleTime: Infinity,
-  });
+  const { data, isFetching, isError } = useQuery(positionQueryOptions());
 
   if (isError)
     setSnackBar({

--- a/src/hooks/common/useTechStackList.tsx
+++ b/src/hooks/common/useTechStackList.tsx
@@ -1,29 +1,21 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getTechStackList as getTechStackListAPI } from '@/service/setting/setting';
-import { ResponseBody, TechStackItem } from '@/utils/type';
 import { useSetRecoilState } from 'recoil';
 import { snackbarState } from '@/store/CommonStateStore';
+import { techListQueryOptions } from '@/utils/tanstackQueryOptions/settingsQuery';
 
 export function useTechStackList() {
   const setSnackBar = useSetRecoilState(snackbarState);
-  const { data, isFetching, isError } = useQuery<
-    Promise<ResponseBody<TechStackItem[]>>,
-    Error,
-    ResponseBody<TechStackItem[]>
-  >({
-    queryKey: ['techStacks'],
-    queryFn: getTechStackListAPI,
-    staleTime: Infinity,
-  });
+  const { data, isFetching, isError } = useQuery(techListQueryOptions());
 
-  if (isError)
+  if (isError) {
     setSnackBar({
       show: true,
       type: 'ERROR',
       content: '포지션 목록을 가져올 수 없습니다',
     });
+  }
 
   return { data: data?.data || [], isFetching, isError };
 }

--- a/src/service/setting/setting.ts
+++ b/src/service/setting/setting.ts
@@ -1,9 +1,17 @@
+import {
+  PositionItem,
+  ResponseBody,
+  TechStackCategory,
+  TechStackItem,
+  TechStackWithCategory,
+} from '@/utils/type';
+
 const publicURL = process.env.NEXT_PUBLIC_URL;
 
 /**
  * 포지션 목록 조회
  */
-export async function getPositionList() {
+export async function getPositionList(): Promise<ResponseBody<PositionItem[]>> {
   const response = await fetch(`${publicURL}/api/setting/position`);
   return await response.json();
 }
@@ -11,7 +19,9 @@ export async function getPositionList() {
 /**
  * 기술스택 목록 조회
  */
-export async function getTechStackList() {
+export async function getTechStackList(): Promise<
+  ResponseBody<TechStackItem[]>
+> {
   const response = await fetch(`${publicURL}/api/setting/tech-stack`);
   return await response.json();
 }
@@ -19,7 +29,9 @@ export async function getTechStackList() {
 /**
  * 기술스택 카테고리 목록 조회
  */
-export async function getTechStackCategoryList() {
+export async function getTechStackCategoryList(): Promise<
+  ResponseBody<TechStackCategory[]>
+> {
   const response = await fetch(`${publicURL}/api/setting/tech-stack-category`);
   return await response.json();
 }
@@ -27,7 +39,9 @@ export async function getTechStackCategoryList() {
 /**
  * 기술스택 카테고리-기술스택 목록 조회
  */
-export async function getTechStackListWithCategory() {
+export async function getTechStackListWithCategory(): Promise<
+  ResponseBody<TechStackWithCategory[]>
+> {
   const response = await fetch(
     `${publicURL}/api/setting/tech-stack-with-category`,
   );

--- a/src/utils/tanstackQueryOptions/settingsQuery.ts
+++ b/src/utils/tanstackQueryOptions/settingsQuery.ts
@@ -1,0 +1,43 @@
+import { queryOptions } from '@tanstack/react-query';
+import {
+  getPositionList,
+  getTechStackCategoryList,
+  getTechStackList,
+  getTechStackListWithCategory,
+} from '@/service/setting/setting';
+
+export function positionQueryOptions() {
+  return queryOptions({
+    queryKey: ['positions'],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: getPositionList,
+  });
+}
+
+export function techCategoryQueryOptions() {
+  return queryOptions({
+    queryKey: ['techStackCategoryList'],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: getTechStackCategoryList,
+  });
+}
+
+export function techMapQueryOptions() {
+  return queryOptions({
+    queryKey: ['techStackListWithCategory'],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: getTechStackListWithCategory,
+  });
+}
+
+export function techListQueryOptions() {
+  return queryOptions({
+    queryKey: ['techStacks'],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: getTechStackList,
+  });
+}


### PR DESCRIPTION
# 🎋 작업중인 브랜치 

Refactor/#17/refactor query options

<br/>

# 💡 작업 내용 

### 1. 정적쿼리 옵션 수정 & 리팩토링 

<br/>

# 🔑  변경된 사항 

## 1. 정적쿼리 옵션 수정 & 리팩토링 

<br/>

c8cac1e5b049ff03acef422457c01093215d6f5f
- 정적쿼리에 공통적으로 사용되는 쿼리옵션을 파일로 분리하고, gcTime이 적용되지 않도록 수정했습니다.

5e47de3ea67bd60a999374b0c854431aca2090e5
-  쿼리옵션 타입추론을 위해, 사용되는 api에 리턴타입을 추가했습니다. 

1c237de365fe1831ab4e75f176431150934ea12e

<br/>




# ✏️  비고 (선택)
> 다른 리뷰어 또는 팀원에게 전달하고 싶은 추가 정보나 요청사항을 여기에 추가해주세요.


<br/>

# ✅  Todo 목록 (선택)
> 필요한 경우 추가 작업이나 변경 사항을 추적하기 위해 Todo 목록을 여기에 추가할 수 있습니다. 
