### PR TITLE
projectConfig feature 관련 Suspense & ErrorBoundary 작업

### DIFF
--- a/src/app/api/post/[slug]/route.ts
+++ b/src/app/api/post/[slug]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest } from 'next/server';
 import publicApi from '@/app/api/_interceptor/publicApi';
-import authApi from '@/app/api/_interceptor/authApi';
 import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 
 export async function GET(
@@ -10,25 +9,7 @@ export async function GET(
   let res: Response;
   if (params.slug === 'search') {
     const queryParams = req.nextUrl.search;
-    res = await publicApi(`/api/board/search/public${queryParams}`);
-  } else {
-    throw Error('Unknown Api Route');
-  }
-
-  return routeResponse(req, res);
-}
-
-export async function PATCH(
-  req: NextRequest,
-  { params }: { params: { slug: string } },
-) {
-  let res: Response;
-  if (params.slug === 'recruitment-status') {
-    const { searchParams } = new URL(req.url);
-    const boardId = searchParams.get('boardId');
-    res = await authApi(`/api/board/${boardId}/recruitment-status`, {
-      method: req.method,
-    });
+    res = await publicApi(`/api/post/search/public${queryParams}`);
   } else {
     throw Error('Unknown Api Route');
   }

--- a/src/app/api/post/public/route.ts
+++ b/src/app/api/post/public/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   const method = req.method;
 
   const res = await publicApi(
-    `/api/board/${searchParams.get('postId')}/public`,
+    `/api/post/${searchParams.get('postId')}/public`,
     {
       method,
     },

--- a/src/app/api/post/route.ts
+++ b/src/app/api/post/route.ts
@@ -4,31 +4,22 @@ import { NextRequest } from 'next/server';
 import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 import { JSONReplaceBigInt } from '@/shared/utils/jsonUtils';
 
-/**
- * 게시글 상세조회
- * @param req
- * @constructor
- */
+// todo - 라우트 public, private 구분
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const postId = searchParams.get('postId');
 
-  const res = await publicApi(`/api/board/${postId}/public`);
+  const res = await publicApi(`/api/post/${postId}/public`);
 
   return routeResponse(req, res);
 }
 
-/**
- * 게시글 생성
- * @param req
- * @constructor
- */
 export async function POST(req: NextRequest) {
-  const { board, project } = await req.json();
+  const data = await req.json();
 
-  const res = await authApi('/api/board', {
+  const res = await authApi('/api/post', {
     method: 'POST',
-    body: JSONReplaceBigInt({ board, project }),
+    body: JSONReplaceBigInt(data),
   });
 
   return routeResponse(req, res);

--- a/src/app/api/projectConfig/pmAuth/route.ts
+++ b/src/app/api/projectConfig/pmAuth/route.ts
@@ -1,18 +1,13 @@
 import { NextRequest } from 'next/server';
-import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 import authApi from '@/app/api/_interceptor/authApi';
 import { JSONReplaceBigInt } from '@/shared/utils/jsonUtils';
+import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 
-/**
- * 프로젝트 설정 - 크루 권한 업데이트
- * @param req
- * @constructor
- */
 export async function PUT(req: NextRequest) {
   const reqData = await req.json();
   const method = req.method;
 
-  const res = await authApi('/api/project/setting/crewAuth', {
+  const res = await authApi('/api/projectConfig/pmAuth', {
     method,
     body: JSONReplaceBigInt(reqData),
   });

--- a/src/app/api/projectConfig/post/route.ts
+++ b/src/app/api/projectConfig/post/route.ts
@@ -3,32 +3,22 @@ import authApi from '@/app/api/_interceptor/authApi';
 import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 import { JSONReplaceBigInt } from '@/shared/utils/jsonUtils';
 
-/**
- * 프로젝트 세팅 - 프로젝트 게시글 정보 조회
- * @param req
- * @constructor
- */
 export async function GET(req: NextRequest) {
   const method = req.method;
   const { searchParams } = new URL(req.url);
   const projectId = searchParams.get('projectId');
 
-  const res = await authApi(`/api/project/setting/board/${projectId}`, {
+  const res = await authApi(`/api/projectConfig/postInfo/${projectId}`, {
     method,
   });
   return routeResponse(req, res);
 }
 
-/**
- * 프로젝트 설정 - 프로젝트 게시글정보 수정
- * @param req
- * @constructor
- */
 export async function PUT(req: NextRequest) {
   const reqData = await req.json();
   const method = req.method;
 
-  const res = await authApi('/api/project/setting/board', {
+  const res = await authApi('/api/projectConfig/postInfo', {
     method,
     body: JSONReplaceBigInt(reqData),
   });

--- a/src/app/api/projectConfig/project/route.ts
+++ b/src/app/api/projectConfig/project/route.ts
@@ -3,32 +3,22 @@ import authApi from '@/app/api/_interceptor/authApi';
 import { routeResponse } from '@/app/api/_interceptor/routeResponse';
 import { JSONReplaceBigInt } from '@/shared/utils/jsonUtils';
 
-/**
- * 프로젝트 세팅 - 프로젝트 정보 조회
- * @param req
- * @constructor
- */
 export async function GET(req: NextRequest) {
   const method = req.method;
   const { searchParams } = new URL(req.url);
   const projectId = searchParams.get('projectId');
 
-  const res = await authApi(`/api/project/setting/info/${projectId}/public`, {
+  const res = await authApi(`/api/projectConfig/projectInfo/${projectId}`, {
     method,
   });
   return routeResponse(req, res);
 }
 
-/**
- * 프로젝트 설정 - 프로젝트 정보 수정
- * @param req
- * @constructor
- */
 export async function PUT(req: NextRequest) {
   const reqData = await req.json();
   const method = req.method;
 
-  const res = await authApi('/api/project/setting/info', {
+  const res = await authApi('/api/projectConfig/projectInfo', {
     method,
     body: JSONReplaceBigInt(reqData),
   });

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -2,10 +2,12 @@
 
 import PostDetail from '@/features/post/public/contents/postDetail/PostDetail';
 
-export default function PostPage({
+const PostPage = ({
   params: { slug: postId },
 }: {
   params: { slug: string };
-}) {
+}) => {
   return <PostDetail postId={postId} />;
-}
+};
+
+export default PostPage;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,7 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       DEFAULT_SEARCH_POST_PARAM,
     );
     const postSiteMap: MetadataRoute.Sitemap = res.data.content.map((post) => ({
-      url: `${DOMAIN}/post?postId=${post.boardId}&amp;projectId=${post.project.projectId}`,
+      url: `${DOMAIN}/post?postId=${post.postId}&amp;projectId=${post.project.projectId}`,
       lastModified: new Date(post.updateDate),
       priority: 0.8,
     }));

--- a/src/features/post/public/components/postDetail/ApplyPositionDropdown.tsx
+++ b/src/features/post/public/components/postDetail/ApplyPositionDropdown.tsx
@@ -17,7 +17,7 @@ import { PostDetailData } from '@/service/post/public/getPostDetail';
 import { projectApplyPositionState } from '@/features/post/public/store/ApplyPositionStateStore';
 
 type ApplyPositionDropdownProps = {
-  applyPositions: PostDetailData['boardPositions'];
+  applyPositions: PostDetailData['postPositions'];
 };
 
 const ApplyPositionDropdown = ({

--- a/src/features/post/public/components/postDetail/PostInformation.tsx
+++ b/src/features/post/public/components/postDetail/PostInformation.tsx
@@ -6,7 +6,7 @@ interface InfoProps {
 }
 
 const PostInformation = ({ postInfo }: InfoProps) => {
-  const { boardPositions, contact } = postInfo;
+  const { postPositions, contact } = postInfo;
 
   return (
     <article className='grid grid-cols-2 gap-y-8 mobile:gap-y-0 mobile:grid-cols-1 mobile:text-sm'>
@@ -30,9 +30,11 @@ const PostInformation = ({ postInfo }: InfoProps) => {
           모집 분야
         </h3>
         <ul className='flex w-[calc(100%-130px)] gap-1 items-center overflow-auto'>
-          {boardPositions.length > 0 &&
-            boardPositions.map((boardPosition) => {
-              const { positionId, positionName } = boardPosition.position;
+          {postPositions.length > 0 &&
+            postPositions.map((postPosition) => {
+              const {
+                position: { positionId, positionName },
+              } = postPosition;
               return (
                 <Badge
                   key={positionId.toString()}

--- a/src/features/post/public/components/postDetail/ProjectInformation.tsx
+++ b/src/features/post/public/components/postDetail/ProjectInformation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import TechStackImage from '@/components/techStack/public/TechStackImage';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 
 type ProjectPublicInfoProps = {
   projectInfo: ProjectInfoSummary;

--- a/src/features/post/public/components/posts/PostCard.tsx
+++ b/src/features/post/public/components/posts/PostCard.tsx
@@ -9,7 +9,7 @@ import { PostInfoSummary } from '@/features/post/public/service/getPostList';
 
 const PostCard = ({ postInfo }: { postInfo: PostInfoSummary }) => {
   const {
-    boardId,
+    postId,
     title,
     project: {
       projectName,
@@ -18,13 +18,13 @@ const PostCard = ({ postInfo }: { postInfo: PostInfoSummary }) => {
       projectSubject,
       technologyStacks,
     },
-    boardPositions,
+    postPositions,
     user: { profileImgSrc, nickname, trustGrade },
   } = postInfo;
 
   return (
     <div className='p-4'>
-      <Link aria-label={`${title}로 가기`} href={`/post/${boardId}`}>
+      <Link aria-label={`${title}로 가기`} href={`/post/${postId}`}>
         <article>
           <h3 className='text-xl font-bold  truncate mb-1'>{title}</h3>
           <section className='mt-4 mb-2 flex items-center text-base text-gray-600 font-medium'>
@@ -75,9 +75,9 @@ const PostCard = ({ postInfo }: { postInfo: PostInfoSummary }) => {
               </div>
             </article>
           </section>
-          {boardPositions.length > 0 && (
+          {postPositions.length > 0 && (
             <section>
-              <h4 id={`recruit-card-position-${boardId}`} className='sr-only'>
+              <h4 id={`recruit-card-position-${postId}`} className='sr-only'>
                 모집 포지션
               </h4>
               <article className='flex items-center gap-2 mt-5'>
@@ -85,7 +85,7 @@ const PostCard = ({ postInfo }: { postInfo: PostInfoSummary }) => {
                   aria-labelledby='recruit-card-position'
                   className='basis-[200px] mobile:basis-[180px] flex items-center'
                 >
-                  {boardPositions
+                  {postPositions
                     .slice(0, 3)
                     .map(({ position: { positionId, positionName } }) => (
                       <li key={positionId.toString()}>
@@ -97,14 +97,14 @@ const PostCard = ({ postInfo }: { postInfo: PostInfoSummary }) => {
                       </li>
                     ))}
                 </ul>
-                {boardPositions.length > 3 && (
+                {postPositions.length > 3 && (
                   <div className='flex items-center space-x-2'>
                     <div>
                       <span className='sr-only'>외 </span>
                       <FaPlusCircle aria-hidden={true} />
                     </div>
                     <div className='pt-1 leading-none text-greyDarkblue/80 font-semibold'>
-                      {boardPositions.length - 3}
+                      {postPositions.length - 3}
                       <span className='sr-only'>개</span>
                     </div>
                   </div>

--- a/src/features/post/public/contents/postDetail/ApplyProject.tsx
+++ b/src/features/post/public/contents/postDetail/ApplyProject.tsx
@@ -57,7 +57,7 @@ const ApplyProject = ({ postInfo }: { postInfo: PostDetailData }) => {
 
   return (
     <footer className='flex justify-center gap-5 my-5'>
-      <ApplyPositionDropdown applyPositions={postInfo.boardPositions} />
+      <ApplyPositionDropdown applyPositions={postInfo.postPositions} />
       <Button
         type='button'
         size='lg'

--- a/src/features/post/public/contents/postDetail/PostDetail.tsx
+++ b/src/features/post/public/contents/postDetail/PostDetail.tsx
@@ -1,7 +1,7 @@
 import ProjectInformation from '@/features/post/public/components/postDetail/ProjectInformation';
 import ApplyProject from '@/features/post/public/contents/postDetail/ApplyProject';
 import { usePostDetail } from '@/service/post/public/getPostDetail';
-import { useProjectPublicInfo } from '@/service/project/public/getProjectPublicInfo';
+import { useProjectSummaryInfo } from '@/service/project/public/getProjectInfoSummary';
 import PostInformation from '@/features/post/public/components/postDetail/PostInformation';
 import PostIntroduction from '@/features/post/public/components/postDetail/PostIntroduction';
 import PostTitle from '@/features/post/public/components/postDetail/PostTitle';
@@ -16,7 +16,7 @@ const PostDetail = ({ postId }: PostDetailProps) => {
 
   const postInfo = postRes.data;
 
-  const { data: projectRes } = useProjectPublicInfo(postInfo.projectId);
+  const { data: projectRes } = useProjectSummaryInfo(postInfo.projectId);
 
   const projectInfo = projectRes.data;
 

--- a/src/features/post/public/contents/posts/Posts.tsx
+++ b/src/features/post/public/contents/posts/Posts.tsx
@@ -68,10 +68,10 @@ const Posts = () => {
             >
               {infos.map((info) => (
                 <li
-                  key={info.boardId.toString()}
+                  key={info.postId.toString()}
                   className='flex-col w-[280px] max-h-[330px] rounded-xl border-2 shadow-lg mobile:w-full mobile:mt-2'
                 >
-                  <PostCard key={info.boardId.toString()} postInfo={info} />
+                  <PostCard key={info.postId.toString()} postInfo={info} />
                 </li>
               ))}
             </ul>

--- a/src/features/post/public/service/getPostList.ts
+++ b/src/features/post/public/service/getPostList.ts
@@ -34,11 +34,10 @@ export const createQueryParams = (params: SearchPostParams) => {
 
 export type PostInfoSummary = {
   project: ProjectInfoSummary;
-  boardId: bigint;
+  postId: bigint;
   title: string;
   recruitmentStatus: boolean;
-  boardPositions: { boardPositionId: bigint | number; position: Position }[];
-  boardPageView: number;
+  postPositions: { postPositionId: bigint | number; position: Position }[];
   user: {
     email: string;
     nickname: string;

--- a/src/features/post/public/service/getPostList.ts
+++ b/src/features/post/public/service/getPostList.ts
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import { request } from '@/utils/clientApi/request';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { PageResponseBody } from '@/types/responseBody';
 import { TrustGrade } from '@/types/data/trustGrade';
 import { Position } from '@/types/data/position';

--- a/src/features/project/private/components/myProjects/ProjectCard.tsx
+++ b/src/features/project/private/components/myProjects/ProjectCard.tsx
@@ -2,7 +2,7 @@ import { format } from 'date-fns';
 import Link from 'next/link';
 import TechStackImage from '@/components/techStack/public/TechStackImage';
 import { FaPlusCircle } from '@react-icons/all-files/fa/FaPlusCircle';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 
 interface ProjectCardProps {
   projectPost: ProjectInfoSummary;

--- a/src/features/project/private/contents/myProject/ProjectContentsSkeleton.tsx
+++ b/src/features/project/private/contents/myProject/ProjectContentsSkeleton.tsx
@@ -6,11 +6,13 @@ import { NoticeSkeleton } from '@/features/projectNotice/private/contents/Notice
 import { PROJECT_MENU } from '@/features/project/private/constants/myProject/projectMenu';
 import { projectActiveNavState } from '@/features/project/private/store/myProject/ProjectNavTabStateStore';
 import CrewsSkeleton from '@/features/projectCrews/private/contents/CrewsSkeleton';
+import ProjectConfigSkeleton from '@/features/projectConfig/private/contents/ProjectConfigSkeleton';
 
 const {
   TASK: { value: PROJECT_TASK },
   CREWS: { value: PROJECT_CREWS },
   NOTICE: { value: PROJECT_NOTICE },
+  SETTING: { value: PROJECT_SETTING },
 } = PROJECT_MENU;
 
 const ProjectContentsSkeleton = () => {
@@ -22,6 +24,8 @@ const ProjectContentsSkeleton = () => {
       return <CrewsSkeleton />;
     case PROJECT_NOTICE:
       return <NoticeSkeleton />;
+    case PROJECT_SETTING:
+      return <ProjectConfigSkeleton />;
     default:
       throw Error(`Unknown Project NavTab: ${activeNavTab}`);
   }

--- a/src/features/project/private/contents/myProject/ProjectInfo.tsx
+++ b/src/features/project/private/contents/myProject/ProjectInfo.tsx
@@ -2,7 +2,7 @@
 
 import TechStackImage from '@/components/techStack/public/TechStackImage';
 import { useRecoilValue } from 'recoil';
-import { useProjectPublicInfo } from '@/service/project/public/getProjectPublicInfo';
+import { useProjectSummaryInfo } from '@/service/project/public/getProjectInfoSummary';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
 import ProjectInfoItem from '@/features/project/private/components/myProject/ProjectInfoItem';
@@ -11,7 +11,7 @@ const ProjectInfo = () => {
   const projectId = useRecoilValue(projectIdState);
   const {
     data: { data },
-  } = useProjectPublicInfo(numStrToBigInt(projectId));
+  } = useProjectSummaryInfo(numStrToBigInt(projectId));
 
   const { projectName, projectSubject, startDate, endDate, technologyStacks } =
     data;

--- a/src/features/project/private/service/myProjects/getMyProjects.ts
+++ b/src/features/project/private/service/myProjects/getMyProjects.ts
@@ -1,7 +1,7 @@
 import { request } from '@/utils/clientApi/request';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { ITEM_COUNT_PER_PAGE } from '@/constants/pagination';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { PageResponseBody } from '@/types/responseBody';
 import sortByStartDate from '@/utils/sortByStartDate';
 

--- a/src/features/projectConfig/private/components/postInfo/Contact.tsx
+++ b/src/features/projectConfig/private/components/postInfo/Contact.tsx
@@ -1,10 +1,10 @@
 import { useRecoilState } from 'recoil';
 import Input from '@/shared/ui/Input';
 import { postInfoFormFieldSelector } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import { PostDetailData } from '@/service/post/public/getPostDetail';
+import { PostConfigData } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 type ContactProps = {
-  initData: PostDetailData['contact'];
+  initData: PostConfigData['contact'];
 };
 
 const Contact = ({ initData }: ContactProps) => {

--- a/src/features/projectConfig/private/components/postInfo/Content.tsx
+++ b/src/features/projectConfig/private/components/postInfo/Content.tsx
@@ -1,10 +1,10 @@
 import { useRecoilState } from 'recoil';
 import TextArea from '@/shared/ui/TextArea';
 import { postInfoFormFieldSelector } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import { PostDetailData } from '@/service/post/public/getPostDetail';
+import { PostConfigData } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 type ContentProps = {
-  initData: PostDetailData['content'];
+  initData: PostConfigData['content'];
 };
 
 const Content = ({ initData }: ContentProps) => {

--- a/src/features/projectConfig/private/components/postInfo/PostPositions.tsx
+++ b/src/features/projectConfig/private/components/postInfo/PostPositions.tsx
@@ -6,11 +6,11 @@ import SelectSkeleton from '@/shared/ui/skeleton/SelectSkeleton';
 import FieldQueryBoundary from '@/components/error/FieldQueryBoundary';
 import { Field, Label } from '@headlessui/react';
 
-type BoardPositionsProps = {
+type PostPositionsProps = {
   initData: PositionId[];
 };
 
-const BoardPositions = ({ initData }: BoardPositionsProps) => {
+const PostPositions = ({ initData }: PostPositionsProps) => {
   const [positionsId, setPositionsId] = useRecoilState(
     postInfoFormFieldSelector('positionIds'),
   );
@@ -34,4 +34,4 @@ const BoardPositions = ({ initData }: BoardPositionsProps) => {
   );
 };
 
-export default BoardPositions;
+export default PostPositions;

--- a/src/features/projectConfig/private/components/postInfo/RecruitmentStatus.tsx
+++ b/src/features/projectConfig/private/components/postInfo/RecruitmentStatus.tsx
@@ -1,10 +1,10 @@
 import { Switch } from '@headlessui/react';
 import { useRecoilState } from 'recoil';
 import { postInfoFormFieldSelector } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import { PostDetailData } from '@/service/post/public/getPostDetail';
+import { PostConfigData } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 type RecruitmentStatusProps = {
-  initData: PostDetailData['recruitmentStatus'];
+  initData: PostConfigData['recruitmentStatus'];
 };
 
 const RecruitmentStatus = ({ initData }: RecruitmentStatusProps) => {

--- a/src/features/projectConfig/private/components/postInfo/Title.tsx
+++ b/src/features/projectConfig/private/components/postInfo/Title.tsx
@@ -1,10 +1,10 @@
 import { useRecoilState } from 'recoil';
 import Input from '@/shared/ui/Input';
 import { postInfoFormFieldSelector } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import { PostDetailData } from '@/service/post/public/getPostDetail';
+import { PostConfigData } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 type TitleProps = {
-  initData: PostDetailData['title'];
+  initData: PostConfigData['title'];
 };
 
 const Title = ({ initData }: TitleProps) => {

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectDateControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectDateControl.tsx
@@ -3,7 +3,7 @@ import DateInput from '@/shared/ui/DateInput';
 import { useRecoilState } from 'recoil';
 import { addDays, format } from 'date-fns';
 import FormRow from '@/ui/FormRow';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 
 type ProjectDateProps = {

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectDateControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectDateControl.tsx
@@ -3,12 +3,12 @@ import DateInput from '@/shared/ui/DateInput';
 import { useRecoilState } from 'recoil';
 import { addDays, format } from 'date-fns';
 import FormRow from '@/ui/FormRow';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
+import { ProjectConfigData } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 type ProjectDateProps = {
-  initStartDate: ProjectInfoSummary['startDate'];
-  initEndDate: ProjectInfoSummary['endDate'];
+  initStartDate: ProjectConfigData['startDate'];
+  initEndDate: ProjectConfigData['endDate'];
 };
 
 const ConfigProjectDateControl = ({
@@ -31,8 +31,8 @@ const ConfigProjectDateControl = ({
 
   // 시작날짜보다 종료날짜 앞서지 못하도록
   useEffect(() => {
-    const endDateValueNum = parseInt(endDateValue.replaceAll('-', ''));
-    const startDateValueNum = parseInt(startDateValue.replaceAll('-', ''));
+    const endDateValueNum = Number(endDateValue.replaceAll('-', ''));
+    const startDateValueNum = Number(startDateValue.replaceAll('-', ''));
     const initEndMinDate = addDays(new Date(startDateValue), 1);
     if (endDateValueNum <= startDateValueNum) {
       setEndDate(format(initEndMinDate, 'yyyy-MM-dd'));

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectNameControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectNameControl.tsx
@@ -2,10 +2,10 @@ import Input from '@/shared/ui/Input';
 import { useRecoilState } from 'recoil';
 import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
+import { ProjectConfigData } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 type ProjectNameProps = {
-  initData: ProjectInfoSummary['projectName'];
+  initData: ProjectConfigData['projectName'];
 };
 
 const ConfigProjectNameControl = ({ initData }: ProjectNameProps) => {

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectNameControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectNameControl.tsx
@@ -2,7 +2,7 @@ import Input from '@/shared/ui/Input';
 import { useRecoilState } from 'recoil';
 import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 
 type ProjectNameProps = {
   initData: ProjectInfoSummary['projectName'];

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectSubjectControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectSubjectControl.tsx
@@ -2,10 +2,10 @@ import Input from '@/shared/ui/Input';
 import { useRecoilState } from 'recoil';
 import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
+import { ProjectConfigData } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 type ProjectSubjectProps = {
-  initData: ProjectInfoSummary['projectSubject'];
+  initData: ProjectConfigData['projectSubject'];
 };
 
 const ConfigProjectSubjectControl = ({ initData }: ProjectSubjectProps) => {

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectSubjectControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectSubjectControl.tsx
@@ -2,7 +2,7 @@ import Input from '@/shared/ui/Input';
 import { useRecoilState } from 'recoil';
 import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 
 type ProjectSubjectProps = {
   initData: ProjectInfoSummary['projectSubject'];

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectTechStackControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectTechStackControl.tsx
@@ -4,12 +4,12 @@ import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 import SelectSkeleton from '@/shared/ui/skeleton/SelectSkeleton';
 import { bigIntToString } from '@/shared/utils/stringUtils';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { Field, Label } from '@headlessui/react';
 import FieldQueryBoundary from '@/components/error/FieldQueryBoundary';
+import { ProjectConfigData } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 type ProjectTechnologiesProps = {
-  initData: ProjectInfoSummary['technologyStacks'];
+  initData: ProjectConfigData['technologyStacks'];
 };
 
 const ConfigProjectTechStackControl = ({

--- a/src/features/projectConfig/private/components/projectInfo/ConfigProjectTechStackControl.tsx
+++ b/src/features/projectConfig/private/components/projectInfo/ConfigProjectTechStackControl.tsx
@@ -4,7 +4,7 @@ import FormRow from '@/ui/FormRow';
 import { projectInfoFormSelector } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 import SelectSkeleton from '@/shared/ui/skeleton/SelectSkeleton';
 import { bigIntToString } from '@/shared/utils/stringUtils';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import { Field, Label } from '@headlessui/react';
 import FieldQueryBoundary from '@/components/error/FieldQueryBoundary';
 

--- a/src/features/projectConfig/private/contents/ProjectConfig.tsx
+++ b/src/features/projectConfig/private/contents/ProjectConfig.tsx
@@ -9,6 +9,7 @@ import ProjectInfoForm from '@/features/projectConfig/private/contents/projectIn
 import PMAuth from '@/features/projectConfig/private/contents/pmAuth/PMAuth';
 import EndProject from '@/features/projectConfig/private/contents/EndProject';
 import { projectManageAuthStateStore } from '@/features/projectConfig/private/store/ProjectManageAuthStateStore';
+import PMAuthSkeleton from '@/features/projectConfig/private/contents/pmAuth/PMAuthSkeleton';
 
 const ProjectConfig = () => {
   const { configYn: isConfigAccessible } = useRecoilValue(
@@ -24,7 +25,6 @@ const ProjectConfig = () => {
       </ErrorPageContainer>
     );
 
-  // todo - PMAuth suspense boundary & ProjectConfigSkeleton(ProjectContentsSkeleton에 추가)
   return (
     <section className='w-full mx-auto space-y-[100px]'>
       <Suspense fallback={<ProjectInfoFormSkeleton />}>
@@ -33,7 +33,9 @@ const ProjectConfig = () => {
       <Suspense fallback={<PostInfoFormSkeleton />}>
         <PostInfoForm />
       </Suspense>
-      <PMAuth />
+      <Suspense fallback={<PMAuthSkeleton />}>
+        <PMAuth />
+      </Suspense>
       <EndProject />
     </section>
   );

--- a/src/features/projectConfig/private/contents/ProjectConfigSkeleton.tsx
+++ b/src/features/projectConfig/private/contents/ProjectConfigSkeleton.tsx
@@ -1,0 +1,28 @@
+import ProjectInfoFormSkeleton from '@/features/projectConfig/private/contents/projectInfo/ProjectInfoFormSkeleton';
+import PostInfoFormSkeleton from '@/features/projectConfig/private/contents/postInfo/PostInfoFormSkeleton';
+import PMAuthSkeleton from '@/features/projectConfig/private/contents/pmAuth/PMAuthSkeleton';
+import ConfigSummary from '@/features/projectConfig/private/layouts/ConfigSummary';
+import ConfigContainer from '@/features/projectConfig/private/layouts/ConfigContainer';
+import ButtonSkeleton from '@/shared/ui/skeleton/ButtonSkeleton';
+
+const ProjectConfigSkeleton = () => {
+  return (
+    <section className='w-full mx-auto space-y-[100px]'>
+      <ProjectInfoFormSkeleton />
+      <PostInfoFormSkeleton />
+      <PMAuthSkeleton />
+      <ConfigContainer>
+        <ConfigSummary>프로젝트 종료</ConfigSummary>
+        <div className='w-[380px] tablet:w-full flex flex-col items-start justify-center'>
+          <p className='text-danger font-medium mb-5'>
+            &#8251; 프로젝트 종료시, 획득한 신뢰점수를 제외한 프로젝트와 관련된
+            모든 정보가 삭제됩니다. 반드시 멤버들과 상의후 종료해주세요.
+          </p>
+          <ButtonSkeleton size='md'>프로젝트 종료</ButtonSkeleton>
+        </div>
+      </ConfigContainer>
+    </section>
+  );
+};
+
+export default ProjectConfigSkeleton;

--- a/src/features/projectConfig/private/contents/pmAuth/PMAuthRow.tsx
+++ b/src/features/projectConfig/private/contents/pmAuth/PMAuthRow.tsx
@@ -11,10 +11,10 @@ import SelectSkeleton from '@/shared/ui/skeleton/SelectSkeleton';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
 import { projectManageAuthStateStore } from '@/features/projectConfig/private/store/ProjectManageAuthStateStore';
 import {
-  UpdateCrewPMAuthInput,
-  updateCrewPMAuthInputSchema,
-  useUpdateCrewPMAuth,
-} from '@/service/pmAuth/private/updateCrewPMAuth';
+  UpdatePMAuthConfigInput,
+  updatePMAuthConfigInputSchema,
+  useUpdatePMAuthConfig,
+} from '@/features/projectConfig/private/service/pmAuth/updatePMAuthConfig';
 import PMAuthSelector from '@/features/projectConfig/private/components/pmAuth/PMAuthSelector';
 import FieldQueryBoundary from '@/components/error/FieldQueryBoundary';
 
@@ -38,7 +38,7 @@ const PMAuthRow = ({ crew }: CrewAuthRowProps) => {
     value: initCrewAuth.code,
   }));
 
-  const { mutate: updateCrewPMAuth } = useUpdateCrewPMAuth(
+  const { mutate: updateCrewPMAuth } = useUpdatePMAuthConfig(
     numStrToBigInt(projectId),
     crewId,
     userAuth,
@@ -49,12 +49,12 @@ const PMAuthRow = ({ crew }: CrewAuthRowProps) => {
   );
 
   const handleClickSaveButton = () => {
-    const data: UpdateCrewPMAuthInput = {
+    const data: UpdatePMAuthConfigInput = {
       crewAuth: auth.value,
     };
 
     try {
-      updateCrewPMAuthInputSchema.parse(data);
+      updatePMAuthConfigInputSchema.parse(data);
     } catch (e) {
       if (e instanceof ZodError) setErrorSnackbar(e.errors[0].message);
       return;

--- a/src/features/projectConfig/private/contents/postInfo/PostInfoForm.tsx
+++ b/src/features/projectConfig/private/contents/postInfo/PostInfoForm.tsx
@@ -1,26 +1,26 @@
-import BoardPositions from '@/features/projectConfig/private/components/postInfo/BoardPositions';
+import PostPositions from '@/features/projectConfig/private/components/postInfo/PostPositions';
 import Contact from '@/features/projectConfig/private/components/postInfo/Contact';
 import Content from '@/features/projectConfig/private/components/postInfo/Content';
 import ProjectPostInfoSaveButton from '@/features/projectConfig/private/contents/postInfo/PostInfoSaveButton';
 import RecruitmentStatus from '@/features/projectConfig/private/components/postInfo/RecruitmentStatus';
 import { useRecoilValue } from 'recoil';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
-import { usePostDetail } from '@/service/post/public/getPostDetail';
 import PostInfoResetButton from '@/features/projectConfig/private/contents/postInfo/PostInfoResetButton';
 import ConfigContainer from '@/features/projectConfig/private/layouts/ConfigContainer';
 import ConfigSummary from '@/features/projectConfig/private/layouts/ConfigSummary';
 import ConfigContents from '@/features/projectConfig/private/layouts/ConfigContents';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
 import Title from '@/features/projectConfig/private/components/postInfo/Title';
+import { usePostConfig } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 const PostInfoForm = () => {
   const projectId = useRecoilValue(projectIdState);
 
   const {
     data: { data },
-  } = usePostDetail(numStrToBigInt(projectId));
+  } = usePostConfig(numStrToBigInt(projectId));
 
-  const { title, boardPositions, contact, recruitmentStatus, content } = data;
+  const { title, postPositions, contact, recruitmentStatus, content } = data;
 
   return (
     <ConfigContainer>
@@ -33,8 +33,8 @@ const PostInfoForm = () => {
           <Title initData={title} />
         </div>
         <div className='w-[380px] mobile:w-[300px] space-y-5 mobile:space-y-3 mobile:mx-auto'>
-          <BoardPositions
-            initData={boardPositions.map((v) => v.position.positionId)}
+          <PostPositions
+            initData={postPositions.map((v) => v.position.positionId)}
           />
         </div>
         <div className='w-[380px] mobile:w-[300px] space-y-5 mobile:space-y-3 mobile:mx-auto'>

--- a/src/features/projectConfig/private/contents/postInfo/PostInfoResetButton.tsx
+++ b/src/features/projectConfig/private/contents/postInfo/PostInfoResetButton.tsx
@@ -2,7 +2,7 @@ import Button from '@/shared/ui/Button';
 import { useQueryClient } from '@tanstack/react-query';
 import { useResetRecoilState } from 'recoil';
 import { postInfoFormStateStore } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import { POST_DETAIL_QUERY_KEY } from '@/service/post/public/getPostDetail';
+import { POST_CONFIG_QUERY_KEY } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 const PostInfoResetButton = () => {
   const resetProjectSettingBoardInfo = useResetRecoilState(
@@ -14,7 +14,7 @@ const PostInfoResetButton = () => {
   const handleClickResetButton = () => {
     resetProjectSettingBoardInfo();
     queryClient.invalidateQueries({
-      queryKey: [POST_DETAIL_QUERY_KEY],
+      queryKey: [POST_CONFIG_QUERY_KEY],
     });
   };
 

--- a/src/features/projectConfig/private/contents/postInfo/PostInfoSaveButton.tsx
+++ b/src/features/projectConfig/private/contents/postInfo/PostInfoSaveButton.tsx
@@ -4,16 +4,16 @@ import useSnackbar from '@/shared/hooks/useSnackbar';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { ZodError } from 'zod';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
-import { PostDetailData } from '@/service/post/public/getPostDetail';
 import { postInfoFormStateStore } from '@/features/projectConfig/private/store/PostInfoFormStateStore';
-import {
-  updatePostInfoInputSchema,
-  useUpdatePostInfo,
-} from '@/service/post/private/updatePostInfo';
 import { projectManageAuthStateStore } from '@/features/projectConfig/private/store/ProjectManageAuthStateStore';
+import {
+  updatePostConfigInputSchema,
+  useUpdatePostConfig,
+} from '@/features/projectConfig/private/service/post/updatePostConfig';
+import { PostConfigData } from '@/features/projectConfig/private/service/post/getPostConfig';
 
 type PostInfoSaveButtonProps = {
-  initData: PostDetailData;
+  initData: PostConfigData;
 };
 
 const PostInfoSaveButton = ({ initData }: PostInfoSaveButtonProps) => {
@@ -23,19 +23,19 @@ const PostInfoSaveButton = ({ initData }: PostInfoSaveButtonProps) => {
 
   const {
     title: initTitle,
-    boardPositions: initBoardPositions,
+    postPositions: initPostPositions,
     contact: initContact,
     content: initContent,
     recruitmentStatus: initRecruitmentStatus,
-    boardId,
+    postId,
   } = initData;
 
   const { title, positionIds, contact, content, recruitmentStatus } =
     useRecoilValue(postInfoFormStateStore);
 
-  const { mutate: updatePostInfo, isPending } = useUpdatePostInfo(
+  const { mutate: updatePostInfo, isPending } = useUpdatePostConfig(
     numStrToBigInt(projectId),
-    boardId,
+    postId,
     userAuth,
     {
       onSuccess: (res) => setSuccessSnackbar(res.message),
@@ -46,12 +46,12 @@ const PostInfoSaveButton = ({ initData }: PostInfoSaveButtonProps) => {
   const handleSavePostInfButton = () => {
     const data = {
       projectId: numStrToBigInt(projectId),
-      boardId,
+      postId,
       title: title ? title : initTitle,
       positionIds:
         positionIds.length > 0
           ? positionIds
-          : initBoardPositions.map((v) => v.position.positionId),
+          : initPostPositions.map((v) => v.position.positionId),
       contact: contact ? contact : initContact,
       content: content ? content : initContent,
       recruitmentStatus:
@@ -59,7 +59,7 @@ const PostInfoSaveButton = ({ initData }: PostInfoSaveButtonProps) => {
     };
 
     try {
-      updatePostInfoInputSchema.parse(data);
+      updatePostConfigInputSchema.parse(data);
     } catch (e: unknown) {
       if (e instanceof ZodError) setErrorSnackbar(e.errors[0].message);
       return;

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoForm.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoForm.tsx
@@ -1,5 +1,5 @@
 import { useRecoilValue } from 'recoil';
-import { useProjectPublicInfo } from '@/service/project/public/getProjectPublicInfo';
+import { useProjectSummaryInfo } from '@/service/project/public/getProjectInfoSummary';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
 import ProjectInfoResetButton from '@/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton';
@@ -17,7 +17,7 @@ const ProjectInfoForm = () => {
 
   const {
     data: { data: projectInfo },
-  } = useProjectPublicInfo(numStrToBigInt(projectId));
+  } = useProjectSummaryInfo(numStrToBigInt(projectId));
 
   const { projectName, projectSubject, startDate, endDate, technologyStacks } =
     projectInfo;

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoForm.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoForm.tsx
@@ -1,5 +1,4 @@
 import { useRecoilValue } from 'recoil';
-import { useProjectSummaryInfo } from '@/service/project/public/getProjectInfoSummary';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
 import ProjectInfoResetButton from '@/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton';
@@ -11,13 +10,14 @@ import ConfigContents from '@/features/projectConfig/private/layouts/ConfigConte
 import ConfigProjectNameControl from '@/features/projectConfig/private/components/projectInfo/ConfigProjectNameControl';
 import ConfigProjectSubjectControl from '@/features/projectConfig/private/components/projectInfo/ConfigProjectSubjectControl';
 import ConfigProjectDateControl from '@/features/projectConfig/private/components/projectInfo/ConfigProjectDateControl';
+import { useProjectConfig } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 const ProjectInfoForm = () => {
   const projectId = useRecoilValue(projectIdState);
 
   const {
     data: { data: projectInfo },
-  } = useProjectSummaryInfo(numStrToBigInt(projectId));
+  } = useProjectConfig(numStrToBigInt(projectId));
 
   const { projectName, projectSubject, startDate, endDate, technologyStacks } =
     projectInfo;

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton.tsx
@@ -1,8 +1,8 @@
 import Button from '@/shared/ui/Button';
 import { useResetRecoilState } from 'recoil';
 import { useQueryClient } from '@tanstack/react-query';
-import { PROJECT_INFO_SUMMARY_QUERY_KEY } from '@/service/project/public/getProjectInfoSummary';
 import { projectInfoFormStateStore } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
+import { PROJECT_CONFIG_QUERY_KEY } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 const ProjectInfoResetButton = () => {
   const resetProjectSettingInfo = useResetRecoilState(
@@ -14,7 +14,7 @@ const ProjectInfoResetButton = () => {
   const handleClickResetButton = () => {
     resetProjectSettingInfo();
     queryClient.invalidateQueries({
-      queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY],
+      queryKey: [PROJECT_CONFIG_QUERY_KEY],
     });
   };
 

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoResetButton.tsx
@@ -1,7 +1,7 @@
 import Button from '@/shared/ui/Button';
 import { useResetRecoilState } from 'recoil';
 import { useQueryClient } from '@tanstack/react-query';
-import { PROJECT_PUBLIC_INFO_QUERY_KEY } from '@/service/project/public/getProjectPublicInfo';
+import { PROJECT_INFO_SUMMARY_QUERY_KEY } from '@/service/project/public/getProjectInfoSummary';
 import { projectInfoFormStateStore } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 
 const ProjectInfoResetButton = () => {
@@ -14,7 +14,7 @@ const ProjectInfoResetButton = () => {
   const handleClickResetButton = () => {
     resetProjectSettingInfo();
     queryClient.invalidateQueries({
-      queryKey: [PROJECT_PUBLIC_INFO_QUERY_KEY],
+      queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY],
     });
   };
 

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoSaveButton.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoSaveButton.tsx
@@ -6,15 +6,15 @@ import useSnackbar from '@/shared/hooks/useSnackbar';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { projectInfoFormStateStore } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import {
-  UpdateProjectInfoInput,
-  useUpdateProjectInfo,
-} from '@/service/project/private/updateProjectInfo';
+  UpdateProjectConfigInput,
+  useUpdateProjectConfig,
+} from '@/features/projectConfig/private/service/project/updateProjectConfig';
 import { projectManageAuthStateStore } from '@/features/projectConfig/private/store/ProjectManageAuthStateStore';
+import { ProjectConfigData } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
 type ProjectInfoSaveButtonProps = {
-  initData: ProjectInfoSummary;
+  initData: ProjectConfigData;
 };
 
 const ProjectInfoSaveButton = ({ initData }: ProjectInfoSaveButtonProps) => {
@@ -24,7 +24,7 @@ const ProjectInfoSaveButton = ({ initData }: ProjectInfoSaveButtonProps) => {
   const projectSettingInfo = useRecoilValue(projectInfoFormStateStore);
   const { setSuccessSnackbar, setErrorSnackbar } = useSnackbar();
 
-  const { mutate: updatePost, isPending: isUpdating } = useUpdateProjectInfo(
+  const { mutate: updatePost, isPending: isUpdating } = useUpdateProjectConfig(
     numStrToBigInt(projectId),
     userPMAuth,
     {
@@ -45,7 +45,7 @@ const ProjectInfoSaveButton = ({ initData }: ProjectInfoSaveButtonProps) => {
     const { projectName, projectSubject, startDate, endDate, technologyIds } =
       projectSettingInfo;
 
-    const reqData: UpdateProjectInfoInput = {
+    const reqData: UpdateProjectConfigInput = {
       projectName: projectName ? projectName : initProjectName,
       projectSubject: projectSubject ? projectSubject : initProjectSubject,
       startDate: startDate ? startDate : initStartDate,

--- a/src/features/projectConfig/private/contents/projectInfo/ProjectInfoSaveButton.tsx
+++ b/src/features/projectConfig/private/contents/projectInfo/ProjectInfoSaveButton.tsx
@@ -6,7 +6,7 @@ import useSnackbar from '@/shared/hooks/useSnackbar';
 import { projectIdState } from '@/features/project/private/store/myProject/ProjectIdStateStore';
 import { projectInfoFormStateStore } from '@/features/projectConfig/private/store/ProjectInfoFormStateStore';
 import { numStrToBigInt } from '@/shared/utils/stringUtils';
-import { ProjectInfoSummary } from '@/service/project/public/getProjectPublicInfo';
+import { ProjectInfoSummary } from '@/service/project/public/getProjectInfoSummary';
 import {
   UpdateProjectInfoInput,
   useUpdateProjectInfo,

--- a/src/features/projectConfig/private/service/pmAuth/updatePMAuthConfig.ts
+++ b/src/features/projectConfig/private/service/pmAuth/updatePMAuthConfig.ts
@@ -4,29 +4,31 @@ import { z } from 'zod';
 import { ResponseBody } from '@/types/responseBody';
 import { ApiResult } from '@/shared/types/apiResult';
 
-export const updateCrewPMAuthInputSchema = z.object({
+export const updatePMAuthConfigInputSchema = z.object({
   crewAuth: z.string().nonempty({ message: '프로젝트 권한을 선택해 주세요.' }),
 });
 
-export type UpdateCrewPMAuthInput = z.infer<typeof updateCrewPMAuthInputSchema>;
+export type UpdatePMAuthConfigInput = z.infer<
+  typeof updatePMAuthConfigInputSchema
+>;
 
-export const updateCrewPMAuth = async (
+export const updatePMAuthConfig = async (
   projectId: bigint,
   crewId: bigint,
   userAuth: string,
-  data: UpdateCrewPMAuthInput,
+  data: UpdatePMAuthConfigInput,
 ): Promise<ResponseBody<null>> => {
-  return request('PUT', '/api/project/setting/crewAuth', {
+  return request('PUT', '/api/projectConfig/pmAuth', {
+    ...data,
     projectId,
-    projectMemberId: crewId,
-    authMap: userAuth,
-    projectMemberAuth: data.crewAuth,
+    crewId,
+    userAuth,
   });
 };
 
-type UpdateCrewPMAuthRes = ApiResult<typeof updateCrewPMAuth>;
+type UpdatePMAuthConfigRes = ApiResult<typeof updatePMAuthConfig>;
 
-export const useUpdateCrewPMAuth = (
+export const useUpdatePMAuthConfig = (
   projectId: bigint,
   crewId: bigint,
   userAuth: string,
@@ -34,13 +36,13 @@ export const useUpdateCrewPMAuth = (
     onSuccess,
     onError,
   }: {
-    onSuccess?: (res: UpdateCrewPMAuthRes) => void;
-    onError?: (res: UpdateCrewPMAuthRes) => void;
+    onSuccess?: (res: UpdatePMAuthConfigRes) => void;
+    onError?: (res: UpdatePMAuthConfigRes) => void;
   },
 ) => {
   return useMutation({
-    mutationFn: (data: UpdateCrewPMAuthInput) =>
-      updateCrewPMAuth(projectId, crewId, userAuth, data),
+    mutationFn: (data: UpdatePMAuthConfigInput) =>
+      updatePMAuthConfig(projectId, crewId, userAuth, data),
     onSuccess: (res) => {
       if (res.result === 'success') {
         onSuccess?.(res);

--- a/src/features/projectConfig/private/service/post/getPostConfig.ts
+++ b/src/features/projectConfig/private/service/post/getPostConfig.ts
@@ -1,0 +1,32 @@
+import { Position } from '@/types/data/position';
+import { ResponseBody } from '@/types/responseBody';
+import { request } from '@/utils/clientApi/request';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { bigIntToString } from '@/shared/utils/stringUtils';
+
+export type PostConfigData = {
+  postId: bigint;
+  title: string;
+  content: string;
+  recruitmentStatus: boolean;
+  contact: string;
+  postPositions: {
+    postPositionId: bigint | number;
+    position: Position;
+  }[];
+};
+
+export const getPostConfig = async (
+  projectId: bigint,
+): Promise<ResponseBody<PostConfigData>> => {
+  return await request('GET', `/api/projectConfig/post?projectId=${projectId}`);
+};
+
+export const POST_CONFIG_QUERY_KEY = 'postConfig';
+
+export const usePostConfig = (projectId: bigint) => {
+  return useSuspenseQuery({
+    queryKey: [POST_CONFIG_QUERY_KEY, bigIntToString(projectId)],
+    queryFn: () => getPostConfig(projectId),
+  });
+};

--- a/src/features/projectConfig/private/service/post/updatePostConfig.ts
+++ b/src/features/projectConfig/private/service/post/updatePostConfig.ts
@@ -4,8 +4,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { POST_DETAIL_QUERY_KEY } from '@/service/post/public/getPostDetail';
 import { ResponseBody } from '@/types/responseBody';
 import { ApiResult } from '@/shared/types/apiResult';
+import { POST_CONFIG_QUERY_KEY } from '@/features/projectConfig/private/service/post/getPostConfig';
 
-export const updatePostInfoInputSchema = z.object({
+export const updatePostConfigInputSchema = z.object({
   title: z.string().nonempty({ message: '게시글 제목을 입력해주세요.' }),
   content: z.string().nonempty({ message: '게시글 내용을 입력해주세요.' }),
   recruitmentStatus: z
@@ -19,28 +20,28 @@ export const updatePostInfoInputSchema = z.object({
     .readonly(),
 });
 
-export type UpdatePostInfoInput = z.infer<typeof updatePostInfoInputSchema>;
+export type UpdatePostConfigInput = z.infer<typeof updatePostConfigInputSchema>;
 
-export const updatePostInfo = async (
+export const updatePostConfig = async (
   projectId: bigint,
-  boardId: bigint,
+  postId: bigint,
   userAuth: string,
-  data: UpdatePostInfoInput,
+  data: UpdatePostConfigInput,
 ): Promise<ResponseBody<null>> => {
-  return await request('PUT', '/api/project/setting/board', {
+  return await request('PUT', '/api/projectConfig/post', {
     ...data,
+    postId,
+    userAuth,
     projectId,
-    boardId,
-    authMap: userAuth,
   });
 };
 
-type UpdatePostInfoRes = ApiResult<typeof updatePostInfo>;
+type UpdatePostInfoRes = ApiResult<typeof updatePostConfig>;
 
 // todo - 백엔드 성공 메세지
-export const useUpdatePostInfo = (
+export const useUpdatePostConfig = (
   projectId: bigint,
-  boardId: bigint,
+  postId: bigint,
   userAuth: string,
   {
     onSuccess,
@@ -53,13 +54,13 @@ export const useUpdatePostInfo = (
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: UpdatePostInfoInput) =>
-      updatePostInfo(projectId, boardId, userAuth, data),
+    mutationFn: (data: UpdatePostConfigInput) =>
+      updatePostConfig(projectId, postId, userAuth, data),
     onSuccess: async (res) => {
       const { result } = res;
       if (result === 'success') {
         await queryClient.invalidateQueries({
-          queryKey: [POST_DETAIL_QUERY_KEY],
+          queryKey: [POST_CONFIG_QUERY_KEY, POST_DETAIL_QUERY_KEY],
         });
         onSuccess?.(res);
       } else {

--- a/src/features/projectConfig/private/service/project/getProjectConfig.ts
+++ b/src/features/projectConfig/private/service/project/getProjectConfig.ts
@@ -1,0 +1,32 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { bigIntToString } from '@/shared/utils/stringUtils';
+import { ResponseBody } from '@/types/responseBody';
+import { TechStack } from '@/types/data/techStack';
+import { request } from '@/utils/clientApi/request';
+
+export type ProjectConfigData = {
+  projectId: bigint;
+  projectName: string;
+  projectSubject: string;
+  startDate: string;
+  endDate: string;
+  technologyStacks: TechStack[];
+};
+
+export const getProjectConfig = async (
+  projectId: bigint,
+): Promise<ResponseBody<ProjectConfigData>> => {
+  return await request(
+    'GET',
+    `/api/projectConfig/project?projectId=${projectId}`,
+  );
+};
+
+export const PROJECT_CONFIG_QUERY_KEY = 'projectConfig';
+
+export const useProjectConfig = (projectId: bigint) => {
+  return useSuspenseQuery({
+    queryKey: [PROJECT_CONFIG_QUERY_KEY, bigIntToString(projectId)],
+    queryFn: () => getProjectConfig(projectId),
+  });
+};

--- a/src/features/projectConfig/private/service/project/updateProjectConfig.ts
+++ b/src/features/projectConfig/private/service/project/updateProjectConfig.ts
@@ -4,8 +4,9 @@ import { request } from '@/utils/clientApi/request';
 import { PROJECT_INFO_SUMMARY_QUERY_KEY } from '@/service/project/public/getProjectInfoSummary';
 import { ResponseBody } from '@/types/responseBody';
 import { ApiResult } from '@/shared/types/apiResult';
+import { PROJECT_CONFIG_QUERY_KEY } from '@/features/projectConfig/private/service/project/getProjectConfig';
 
-const updateProjectInfoInputSchema = z.object({
+const updateProjectConfigInputSchema = z.object({
   projectName: z
     .string()
     .nonempty({ message: '프로젝트 이름을 입력해주세요.' }),
@@ -24,44 +25,44 @@ const updateProjectInfoInputSchema = z.object({
     .readonly(),
 });
 
-export type UpdateProjectInfoInput = z.infer<
-  typeof updateProjectInfoInputSchema
+export type UpdateProjectConfigInput = z.infer<
+  typeof updateProjectConfigInputSchema
 >;
 
-export const updateProjectInfo = async (
+export const updateProjectConfig = async (
   projectId: bigint,
   userAuth: string,
-  data: UpdateProjectInfoInput,
+  data: UpdateProjectConfigInput,
 ): Promise<ResponseBody<null>> => {
-  return await request('PUT', '/api/project/setting/info', {
+  return await request('PUT', '/api/projectConfig/project', {
     ...data,
     projectId,
-    authMap: userAuth,
+    userAuth,
   });
 };
 
-type UpdateProjectInfoRes = ApiResult<typeof updateProjectInfo>;
+type UpdateProjectConfigRes = ApiResult<typeof updateProjectConfig>;
 
 // todo - 백엔드 성공 메세지
-export const useUpdateProjectInfo = (
+export const useUpdateProjectConfig = (
   projectId: bigint,
   userAuth: string,
   {
     onSuccess,
     onError,
   }: {
-    onSuccess?: (res: UpdateProjectInfoRes) => void;
-    onError?: (res: UpdateProjectInfoRes) => void;
+    onSuccess?: (res: UpdateProjectConfigRes) => void;
+    onError?: (res: UpdateProjectConfigRes) => void;
   },
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: UpdateProjectInfoInput) =>
-      updateProjectInfo(projectId, userAuth, data),
+    mutationFn: (data: UpdateProjectConfigInput) =>
+      updateProjectConfig(projectId, userAuth, data),
     onSuccess: async (res) => {
       if (res.result === 'success') {
         await queryClient.invalidateQueries({
-          queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY],
+          queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY, PROJECT_CONFIG_QUERY_KEY],
         });
         onSuccess?.(res);
       } else {

--- a/src/features/projectConfig/private/store/PostInfoFormStateStore.tsx
+++ b/src/features/projectConfig/private/store/PostInfoFormStateStore.tsx
@@ -1,7 +1,7 @@
 import { atom, DefaultValue, selectorFamily } from 'recoil';
-import { UpdatePostInfoInput } from '@/service/post/private/updatePostInfo';
+import { UpdatePostConfigInput } from '@/features/projectConfig/private/service/post/updatePostConfig';
 
-const DEFAULT_POST_INFO_FORM: UpdatePostInfoInput = {
+const DEFAULT_POST_INFO_FORM: UpdatePostConfigInput = {
   title: '',
   content: '',
   recruitmentStatus: null,
@@ -9,21 +9,23 @@ const DEFAULT_POST_INFO_FORM: UpdatePostInfoInput = {
   positionIds: [],
 };
 
-export const postInfoFormStateStore = atom<UpdatePostInfoInput>({
+export const postInfoFormStateStore = atom<UpdatePostConfigInput>({
   key: 'postInfoFormStateStore',
   default: DEFAULT_POST_INFO_FORM,
 });
 
-export const postInfoFormFieldSelector = <K extends keyof UpdatePostInfoInput>(
+export const postInfoFormFieldSelector = <
+  K extends keyof UpdatePostConfigInput,
+>(
   key: K,
 ): ReturnType<typeof postInfoFormFieldSelectorFamily<K>> => {
   return postInfoFormFieldSelectorFamily<K>(key);
 };
 
-const postInfoFormFieldSelectorFamily = <K extends keyof UpdatePostInfoInput>(
+const postInfoFormFieldSelectorFamily = <K extends keyof UpdatePostConfigInput>(
   key: K,
 ) =>
-  selectorFamily<UpdatePostInfoInput[K], K>({
+  selectorFamily<UpdatePostConfigInput[K], K>({
     key: 'postInfoFormFieldSelector',
     get:
       (param) =>

--- a/src/features/projectConfig/private/store/ProjectInfoFormStateStore.tsx
+++ b/src/features/projectConfig/private/store/ProjectInfoFormStateStore.tsx
@@ -1,8 +1,8 @@
 import { atom, DefaultValue, selectorFamily } from 'recoil';
-import { UpdateProjectInfoInput } from '@/service/project/private/updateProjectInfo';
+import { UpdateProjectConfigInput } from '@/features/projectConfig/private/service/project/updateProjectConfig';
 
 interface UpdateProjectInfoFormState
-  extends Omit<UpdateProjectInfoInput, 'technologyIds'> {
+  extends Omit<UpdateProjectConfigInput, 'technologyIds'> {
   technologyIds: string[];
 }
 

--- a/src/service/post/public/getPostDetail.ts
+++ b/src/service/post/public/getPostDetail.ts
@@ -5,7 +5,7 @@ import { ResponseBody } from '@/types/responseBody';
 import { Position } from '@/types/data/position';
 
 export type PostDetailData = {
-  boardId: bigint;
+  postId: bigint;
   projectId: bigint;
   title: string;
   content: string;
@@ -19,8 +19,8 @@ export type PostDetailData = {
   contact: string;
   createDate: string;
   updateDate: string;
-  boardPositions: {
-    boardPositionId: bigint | number;
+  postPositions: {
+    postPositionId: bigint | number;
     position: Position;
   }[];
 };

--- a/src/service/project/private/updateProjectInfo.ts
+++ b/src/service/project/private/updateProjectInfo.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 import { request } from '@/utils/clientApi/request';
-import { PROJECT_PUBLIC_INFO_QUERY_KEY } from '@/service/project/public/getProjectPublicInfo';
+import { PROJECT_INFO_SUMMARY_QUERY_KEY } from '@/service/project/public/getProjectInfoSummary';
 import { ResponseBody } from '@/types/responseBody';
 import { ApiResult } from '@/shared/types/apiResult';
 
@@ -61,7 +61,7 @@ export const useUpdateProjectInfo = (
     onSuccess: async (res) => {
       if (res.result === 'success') {
         await queryClient.invalidateQueries({
-          queryKey: [PROJECT_PUBLIC_INFO_QUERY_KEY],
+          queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY],
         });
         onSuccess?.(res);
       } else {

--- a/src/service/project/public/getProjectInfoSummary.ts
+++ b/src/service/project/public/getProjectInfoSummary.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { bigIntToString } from '@/shared/utils/stringUtils';
 import { ResponseBody } from '@/types/responseBody';
 import { TechStack } from '@/types/data/techStack';
@@ -13,21 +13,17 @@ export type ProjectInfoSummary = {
   technologyStacks: TechStack[];
 };
 
-export const getProjectPublicInfo = async (
+export const getProjectInfoSummary = async (
   projectId: bigint,
 ): Promise<ResponseBody<ProjectInfoSummary>> => {
   return await request('GET', `/api/project/public?projectId=${projectId}`);
 };
 
-export const PROJECT_PUBLIC_INFO_QUERY_KEY = 'projectPublicInfo';
+export const PROJECT_INFO_SUMMARY_QUERY_KEY = 'projectInfoSummary';
 
-export const getProjectPublicInfoQueryOptions = (projectId: bigint) => {
-  return queryOptions({
-    queryKey: [PROJECT_PUBLIC_INFO_QUERY_KEY, bigIntToString(projectId)],
-    queryFn: () => getProjectPublicInfo(projectId),
+export const useProjectSummaryInfo = (projectId: bigint) => {
+  return useSuspenseQuery({
+    queryKey: [PROJECT_INFO_SUMMARY_QUERY_KEY, bigIntToString(projectId)],
+    queryFn: () => getProjectInfoSummary(projectId),
   });
-};
-
-export const useProjectPublicInfo = (projectId: bigint) => {
-  return useSuspenseQuery(getProjectPublicInfoQueryOptions(projectId));
 };


### PR DESCRIPTION
# 🎋 작업중인 브랜치 
refactor/#110/suspense-and-errorHandling-2

<br/>

# 💡 작업 내용 

### 1. getProjectPublicInfo -> getProjectInfoSummary로 변경
### 2. projectConfig 라우트 핸들러 추가 & api/setting 라우트 제거 
### 3. 게시글 feature(post) 관련 api 라우트명, 데이터필드명 prefix 수정(board -> post)
### 4. ProjectConfigSkeleton 추가 

<br/>

# 🔑  변경된 사항 
> 변경된 파일과 그에 대한 간략한 설명을 나열해주세요. 

## 1. getProjectPublicInfo -> getProjectInfoSummary로 변경

<br/>

0ba50720d3dd378da2bbcd0436085bf86ec13334

<br/>

## 2. projectConfig 라우트 핸들러 추가 & api/setting 라우트 제거 

<br/>

691aae05845adeb5862f5dc9b105721459bb8dc3, 1858574fd67c0c8d25eac87a40a3a499c63ff175

<br/>

## 3. 게시글 feature(post) 관련 api 라우트명, 데이터필드명 prefix 수정(board -> post)

<br/>

fa5c9a7af4af11f363e49a555db4bee805e210ab, 156a5ea8e5c87425c8aa076fe66eb92daf120716

<br/>

## 4. ProjectConfigSkeleton 추가 

<br/>

294741681953cdcc4a93f44dd1f01d2ab6f37a01

<br/>

# ✏️  비고 (선택)


<br/>

# ✅  Todo 목록 (선택)
